### PR TITLE
Add custom mojaloop policy for evaluating anchore-cli scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ version: 2.1
 orbs:
   anchore: anchore/anchore-engine@1.6.0
   deploy-kube: mojaloop/deployment@0.1.6
+  slack: circleci/slack@3.4.2
 
 ##
 # defaults
@@ -219,6 +220,13 @@ jobs:
       - setup_remote_docker
       - checkout
       - run:
+          name: Install docker dependencies for anchore
+          command: |
+            apk add --update py-pip docker python-dev libffi-dev openssl-dev gcc libc-dev make jq npm
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
           name: Install AWS CLI dependencies
           command: *defaults_awsCliDependencies
       - attach_workspace:
@@ -226,40 +234,39 @@ jobs:
       - run:
           name: Load the pre-built docker image from workspace
           command: docker load -i /tmp/docker-image.tar
+      - run:
+          name: Download the mojaloop/ci-config repo
+          command: |
+            git clone https://github.com/mojaloop/ci-config /tmp/ci-config
+            # Generate the mojaloop anchore-policy
+            cd /tmp/ci-config/container-scanning && ./mojaloop-policy-generator.js /tmp/mojaloop-policy.json
+      - run:
+          name: Pull base image locally
+          command: |
+            docker pull node:12.16.1-alpine
+      # Analyze the base and derived image
+      # Note: It seems images are scanned in parallel, so preloading the base image result doesn't give us any real performance gain
       - anchore/analyze_local_image:
-          dockerfile_path: ./Dockerfile
-          image_name: ${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
-          # Anchore bug: if policy_failure is `true`, reports don't get written - we manually check for failures below
+          # Force the older version, version 0.7.0 was just published, and is broken
+          anchore_version: v0.6.1
+          image_name: "docker.io/node:12.16.1-alpine $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG"
           policy_failure: false
           timeout: '500'
-      - run:
-          name: Evaluate Failures.
-          command: |
-            if [[ ! $(which jq) ]]; then
-              (set +o pipefail; apk add jq || apt-get install -y jq || yum install -y jq)
-            fi
-            if [[ $(ls anchore-reports/*content-os*.json 2> /dev/null) ]]; then
-              printf "\n%s\n" "The following OS packages are installed:"
-              jq '[.content | sort_by(.package) | .[] | {package: .package, version: .version}]' anchore-reports/*content-os*.json
-            fi
-            if [[ $(ls anchore-reports/*vuln*.json 2> /dev/null) ]]; then
-              printf "\n%s\n" "The following vulnerabilities were found:"
-              jq '[.vulnerabilities | group_by(.package) | .[] | {package: .[0].package, vuln: [.[].vuln]}]' anchore-reports/*vuln*.json
-            fi
+          # Note: if the generated policy is invalid, this will fallback to the default policy, which we don't want!
+          policy_bundle_file_path: /tmp/mojaloop-policy.json
       - run:
           name: Upload Anchore reports to s3
           command: |
             aws s3 cp anchore-reports ${AWS_S3_DIR_ANCHORE_REPORTS}/${CIRCLE_PROJECT_REPONAME}/ --recursive
             aws s3 rm ${AWS_S3_DIR_ANCHORE_REPORTS}/latest/ --recursive --exclude "*" --include "${CIRCLE_PROJECT_REPONAME}*"
             aws s3 cp anchore-reports ${AWS_S3_DIR_ANCHORE_REPORTS}/latest/ --recursive
-
-            # TODO: Enable this when we want to increase the strictness of our security policies
-            # failCount=$(cat anchore-reports/*policy*.json | grep 'fail' | wc -l)
-            # echo "FailCount is: ${failCount}"
-            # if [ $failCount -gt 0 ]; then
-            #   printf "Failed with a policy failure count of: ${failCount}"
-            #   exit 1
-            # fi
+      - run:
+          name: Evaluate failures
+          command: /tmp/ci-config/container-scanning/anchore-result-diff.js anchore-reports/node_12.16.1-alpine-policy.json anchore-reports/${CIRCLE_PROJECT_REPONAME}*-policy.json
+      - slack/status:
+          fail_only: true
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          failure_message: 'Anchore Image Scan failed  for: \`"${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"\`'
       - store_artifacts:
           path: anchore-reports
 
@@ -286,14 +293,9 @@ jobs:
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$CIRCLE_TAG
             echo "Publishing $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG"
             docker push $DOCKER_ORG/$CIRCLE_PROJECT_REPONAME:$RELEASE_TAG
-      - run:
-          name: Slack announcement for tag releases
-          command: |
-            curl -X POST \
-              $SLACK_WEBHOOK_ANNOUNCEMENT \
-              -H 'Content-type: application/json' \
-              -H 'cache-control: no-cache' \
-              -d "{\"text\": \"*${CIRCLE_PROJECT_REPONAME}* - Release \`${CIRCLE_TAG}\`: https://github.com/mojaloop/${CIRCLE_PROJECT_REPONAME}/releases/tag/${CIRCLE_TAG}\"}"
+      - slack/status:
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          success_message: '*"${CIRCLE_PROJECT_REPONAME}"* - Release \`"${CIRCLE_TAG}"\` \nhttps://github.com/mojaloop/"${CIRCLE_PROJECT_REPONAME}"/releases/tag/"${CIRCLE_TAG}"'
 
   deploy:
     executor: deploy-kube/helm-kube
@@ -303,6 +305,10 @@ jobs:
           helm_set_values: |
             --set .central.centraleventprocessor.image.repository=$DOCKER_ORG/$CIRCLE_PROJECT_REPONAME \
             --set .central.centraleventprocessor.image.tag=$CIRCLE_TAG
+      - slack/status:
+          fail_only: true
+          webhook: "$SLACK_WEBHOOK_ANNOUNCEMENT"
+          failure_message: 'Deployment failed for: \`"${DOCKER_ORG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}"\`'
 
 ##
 # Workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.0-alpine as builder
+FROM node:12.16.1-alpine as builder
 USER root
 
 WORKDIR /opt/central-event-processor
@@ -18,16 +18,19 @@ COPY config /opt/central-event-processor/config
 COPY app.js /opt/central-event-processor/
 COPY docs /opt/central-event-processor/docs
 
-FROM node:12.16.0-alpine
-
+FROM node:12.16.1-alpine
 WORKDIR /opt/central-event-processor
-
-COPY --from=builder /opt/central-event-processor .
-RUN npm prune --production
 
 # Create empty log file & link stdout to the application log file
 RUN mkdir ./logs && touch ./logs/combined.log
 RUN ln -sf /dev/stdout ./logs/combined.log
+
+# Create a non-root user: ml-user
+RUN adduser -D ml-user 
+USER ml-user
+
+COPY --chown=ml-user --from=builder /opt/central-event-processor .
+RUN npm prune --production
 
 EXPOSE 3080
 CMD node app.js

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The CEP can then be integrated with a notifier service, to send out notification
 * [Actions Agent flow](#12-actions-agent-flow)
 * [Scheduler flow](#13-scheduler-flow)
 * [Notifier flow (separate service)](#14-notifier-flow-separate-service)
+* [Auditing Dependencies](#15-auditing-dependencies)
+* [Container Scans](#16-container-scans)
 
 ## 1. Deployment
 See the [onboarding guide](onboarding.md) for running the service locally.
@@ -170,9 +172,9 @@ The scheduler coordinates the Action Object that requires to be dispatched. It w
 Email notifier service is a separate app, that observes the same topic for messages with field *from* = `SYSTEM`. Its code is available in the [email-notifier](https://github.com/mojaloop/email-notifier) repository.
 
 
-## Auditing Dependencies
+## 15. Auditing Dependencies
 
-We use `npm-audit-resolver` along with `npm audit` to check dependencies for vulnerabilities, and keep track of resolved dependencies with an `audit-resolv.json` file.
+We use `npm-audit-resolver` along with `npm audit` to check dependencies for node vulnerabilities, and keep track of resolved dependencies with an `audit-resolve.json` file.
 
 To start a new resolution process, run:
 ```bash
@@ -184,4 +186,15 @@ You can then check to see if the CI will pass based on the current dependencies 
 npm run audit:check
 ```
 
-And commit the changed `audit-resolv.json` to ensure that CircleCI will build correctly.
+And commit the changed `audit-resolve.json` to ensure that CircleCI will build correctly.
+
+## 16. Container Scans
+
+As part of our CI/CD process, we use anchore-cli to scan our built docker container for vulnerabilities upon release.
+
+If you find your release builds are failing, refer to the [container scanning](https://github.com/mojaloop/ci-config#container-scanning) in our shared Mojaloop CI config repo. There is a good chance you simply need to update the `mojaloop-policy-generator.js` file and re-run the circleci workflow.
+
+For more information on anchore and anchore-cli, refer to:
+- [Anchore CLI](https://github.com/anchore/anchore-cli)
+- [Circle Orb Registry](https://circleci.com/orbs/registry/orb/anchore/anchore-engine)
+

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -25,204 +25,171 @@
       "madeAt": 1582278197698
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-stream>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>@mojaloop/central-services-logger>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|nodemon>update-notifier>latest-version>package-json>registry-auth-token>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|nodemon>update-notifier>latest-version>package-json>registry-url>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|npm-check-updates>requireg>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|npm-check-updates>update-notifier>latest-version>package-json>registry-auth-token>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|npm-check-updates>update-notifier>latest-version>package-json>registry-url>rc>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|config>json5>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|standard>standard-engine>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|tap-xunit>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|tape>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530626112,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765266726
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415736,
+      "expiresAt": 1589357224759
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415736,
+      "expiresAt": 1589357224759
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>tar>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415737,
+      "expiresAt": 1589357224759
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>tar>mkdirp>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415737,
+      "expiresAt": 1589357224759
     },
     "1179|@mojaloop/central-services-health>@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>rc>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415737,
+      "expiresAt": 1589357224759
     },
     "1179|@mojaloop/central-services-shared>@mojaloop/event-sdk>grpc>node-pre-gyp>rc>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415737,
+      "expiresAt": 1589357224759
     },
     "1179|faucet>minimist": {
       "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "madeAt": 1586765415737,
+      "expiresAt": 1589357224759
     },
     "1179|istanbul>istanbul-api>istanbul-lib-report>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|istanbul>istanbul-api>istanbul-lib-source-maps>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|istanbul>istanbul-api>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|istanbul>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|mockgoose>portfinder>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|npm-check-updates>pacote>cacache>move-concurrently>copy-concurrently>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|npm-check-updates>pacote>npm-registry-fetch>make-fetch-happen>cacache>move-concurrently>copy-concurrently>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|npm-check-updates>pacote>cacache>move-concurrently>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|npm-check-updates>pacote>npm-registry-fetch>make-fetch-happen>cacache>move-concurrently>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|rewire>eslint>file-entry-cache>flat-cache>write>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|standard>eslint>file-entry-cache>flat-cache>write>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|rewire>eslint>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|standard>eslint>mkdirp>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765283073
     },
     "1179|istanbul>istanbul-api>istanbul-reports>handlebars>optimist>minimist": {
-      "decision": "ignore",
-      "madeAt": 1584530632714,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765294915
     },
     "1217|mockgoose>mongodb-prebuilt>mongodb-download>decompress": {
-      "decision": "ignore",
-      "madeAt": 1584530643064,
-      "expiresAt": 1585135395621
+      "decision": "fix",
+      "madeAt": 1586765395736
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "central-event-processor",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1323,9 +1323,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1473,9 +1473,9 @@
       "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -2025,9 +2025,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
         "decompress-tar": "^4.0.0",
@@ -3807,15 +3807,16 @@
       }
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -5217,9 +5218,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.1",
@@ -5316,20 +5317,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mockgoose": {
@@ -6513,30 +6506,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -8438,9 +8407,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -8711,9 +8680,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8731,9 +8700,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.1.tgz",
+      "integrity": "sha512-sgDYfSDPMsA4Hr2/w7vOlrJBlwzmyakk1+hW8ObLvxSp0LA36LcL2XItGvOT3OSblohSdevMuT8FQjLsqyy4sA==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "central-event-processor",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "CEP for Mojaloop Central-Ledger to monitor the notificaion kafka topic and act on it",
   "main": "app.js",
   "dependencies": {


### PR DESCRIPTION
Adds a custom policy for anchore-cli to evaluate the container security during a release

Also:
- adds a default `ml-user` to the dockerfile
- adds some more slack notifications to the announcements channel for different failures
- updates the readme with a new circleci link and info about container scanning


Closes: #1223