### PR TITLE
chore: remove and replace deprecated transitive packages

### DIFF
--- a/.circleci/deprecated-check.js
+++ b/.circleci/deprecated-check.js
@@ -1,0 +1,98 @@
+const { spawnSync } = require('child_process');
+
+function execCommandSync(command) {
+    const [cmd, ...args] = command.split(' '); // Split command into executable and arguments
+    const result = spawnSync(cmd, args, { encoding: 'utf-8', shell: false });
+
+    if (result.error) {
+        throw result.error; // Handle system errors
+    }
+    if (result.status !== 0) {
+        throw new Error(result.stderr || `Command failed with exit code ${result.status}`);
+    }
+    return result.stdout;
+}
+
+const dependenciesMap = new Map();
+const regex = /(?:@[\w-]+\/)?[\w.-]{1,100}@\d{1,10}\.\d{1,10}\.\d{1,10}(?:[-+][\w.-]{1,50})?/g;
+
+function checkDependencySync(dependency) {
+    if (dependenciesMap.has(dependency)) return;
+    try {
+        const output = execCommandSync(`npm view ${dependency}`);
+        if (output.includes('DEPRECATED')) {
+            dependenciesMap.set(dependency, 'DEPRECATED');
+        } else {
+            dependenciesMap.set(dependency, 'active');
+        }
+    } catch (error) {
+        dependenciesMap.set(dependency, 'UNKNOWN');
+    }
+}
+
+function processLinesSync(lines) {
+    for (const line of lines) {
+        const trimmedLine = line.trim();
+        const matches = trimmedLine.matchAll(regex);
+
+        for (const match of matches) {
+            const dependency = match[0];
+            checkDependencySync(dependency);
+        }
+    }
+}
+
+function checkDependenciesSync(command) {
+    try {
+        const stdout = execCommandSync(command);
+        const lines = stdout.trim().split('\n');
+        processLinesSync(lines);
+    } catch (error) {
+        
+        const errorLines = error.toString().trim().split('\n');
+        processLinesSync(errorLines); // Process error lines as well
+    }
+}
+
+function runDependencyCheckSync() {
+    console.log('Checking dependencies at root level...');
+    checkDependenciesSync('npm ls');
+
+    let deprecatedFound = false;
+    let counter = 0;
+    dependenciesMap.forEach((status, dependency) => {
+        if (status === 'DEPRECATED') {
+            counter++;
+            deprecatedFound = true;
+            console.log(`${counter}. ${dependency} ${status}`);
+        }
+    });
+
+    if (deprecatedFound) {
+        console.log('\x1b[31mWARNING!! Deprecated results found at root level.\n\x1b[0m');
+    } else {
+        console.log('\x1b[32mSUCCESS: No deprecated packages found at root level! Congos!!\n\x1b[0m');
+    }
+
+    console.log('Checking all dependencies (including transitive)...');
+    checkDependenciesSync('npm ls --all');
+
+    deprecatedFound = false;
+    counter = 0;
+    dependenciesMap.forEach((status, dependency) => {
+        if (status === 'DEPRECATED') {
+            counter++;
+            deprecatedFound = true;
+            console.log(`${counter}. ${dependency} ${status}`);
+        }
+    });
+
+    if (deprecatedFound) {
+        console.log('\x1b[31mWARNING!! Deprecated results found in dependencies.\n\x1b[0m');
+    } else {
+        console.log('\x1b[32mSUCCESS: No deprecated packages found! Congos!!\x1b[0m');
+    }
+    
+}
+
+runDependencyCheckSync();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1462,6 +1462,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/package-json": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-1.0.1.tgz",
+      "integrity": "sha512-y6jnu76E9C23osz8gEMBayZmaZ69vFOIk8vR1FJL/wbEJ54+9aVG9rLTjQKSXfgYZEr50nw1txBBFfBZZe+bYg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2856,7 +2866,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -5583,45 +5594,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/fs-readfile-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-readfile-promise/-/fs-readfile-promise-2.0.1.tgz",
-      "integrity": "sha512-7+P9eOOMnkIOmtxrBWTzWOBQlE7Nz/cBx9EYTX5hm8DzmZ/Fj9YWeUY2O9G+Q8YblScd1hyEkcmNcZMDj5U8Ug==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2"
-      }
-    },
-    "node_modules/fs-writefile-promise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-writefile-promise/-/fs-writefile-promise-1.0.3.tgz",
-      "integrity": "sha512-yI+wDwj0FsgX7tyIQJR+EP60R64evMSixtGb9AzGWjJVKlF5tCet95KomfqGBg/aIAG1Dhd6wjCOQe5HbX/qLA==",
-      "dependencies": {
-        "mkdirp-promise": "^1.0.0",
-        "pinkie-promise": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/fs-writefile-promise/node_modules/pinkie": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "integrity": "sha512-VFVaU1ysKakao68ktZm76PIdOhvEfoNNRaGkyLln9Os7r0/MCxqHjHyBM7dT3pgTiBybqiPtpqKfpENwdBp50Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fs-writefile-promise/node_modules/pinkie-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "integrity": "sha512-5mvtVNse2Ml9zpFKkWBpGsTPwm3DKhs+c95prO/F6E7d6DN0FPqxs6LONpLNpyD7Iheb7QN4BbUoKJgo+DnkQA==",
-      "dependencies": {
-        "pinkie": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5997,7 +5969,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -6087,25 +6060,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -6367,93 +6321,79 @@
       }
     },
     "node_modules/httpsnippet": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-1.25.0.tgz",
-      "integrity": "sha512-jobE6S923cLuf5BPG6Jf+oLBRkPzv2RPp0dwOHcWwj/t9FwV/t9hyZ46kpT3Q5DHn9iFNmGhrcmmFUBqyjoTQg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-3.0.1.tgz",
+      "integrity": "sha512-RJbzVu9Gq97Ti76MPKAb9AknKbRluRbzOqswM2qgEW48QUShVEIuJjl43dZG5q0Upj2SZlKqzR6B6ah1q5znfg==",
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "debug": "^2.2.0",
-        "event-stream": "3.3.4",
-        "form-data": "3.0.0",
-        "fs-readfile-promise": "^2.0.1",
-        "fs-writefile-promise": "^1.0.3",
-        "har-validator": "^5.0.0",
-        "pinkie-promise": "^2.0.0",
-        "stringify-object": "^3.3.0"
+        "chalk": "^4.1.2",
+        "event-stream": "4.0.1",
+        "form-data": "4.0.0",
+        "har-schema": "^2.0.0",
+        "stringify-object": "3.3.0",
+        "yargs": "^17.4.0"
       },
       "bin": {
         "httpsnippet": "bin/httpsnippet"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/httpsnippet/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": "^14.19.1 || ^16.14.2 || ^18.0.0"
       }
     },
     "node_modules/httpsnippet/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/httpsnippet/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/httpsnippet/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/httpsnippet/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/httpsnippet/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+        "color-name": "~1.1.4"
+      },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/httpsnippet/node_modules/event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
+    "node_modules/httpsnippet/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/httpsnippet/node_modules/form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6463,52 +6403,25 @@
         "node": ">= 6"
       }
     },
-    "node_modules/httpsnippet/node_modules/map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
-    },
-    "node_modules/httpsnippet/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/httpsnippet/node_modules/split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
-      "dependencies": {
-        "through": "2"
-      },
+    "node_modules/httpsnippet/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/httpsnippet/node_modules/stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
-      "dependencies": {
-        "duplexer": "~0.1.1"
-      }
-    },
-    "node_modules/httpsnippet/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/httpsnippet/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=8"
       }
     },
     "node_modules/iconv-lite": {
@@ -8543,23 +8456,12 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-1.1.0.tgz",
-      "integrity": "sha512-xzB0UZFcW1UGS2xkXeDh39jzTP282lb3Vwp4QzCQYmkTn4ysaV5dBdbkOXmhkcE1TQlZebQlgTceaWvDr3oFgw==",
-      "deprecated": "This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.",
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "mkdirp": ">=0.5.0"
       }
     },
     "node_modules/mock-json-schema": {
@@ -10158,6 +10060,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10166,6 +10069,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -12039,6 +11943,7 @@
       "integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
       "dev": true,
       "dependencies": {
+        "@npmcli/package-json": "^1.0.1",
         "chalk": "^2.4.2",
         "conventional-changelog": "3.1.25",
         "conventional-changelog-config-spec": "2.1.0",
@@ -12051,7 +11956,6 @@
         "find-up": "^5.0.0",
         "git-semver-tags": "^4.0.0",
         "semver": "^7.1.1",
-        "stringify-package": "^1.0.1",
         "yargs": "^16.0.0"
       },
       "bin": {
@@ -12328,13 +12232,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/stringify-package": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
-      "deprecated": "This module is not used anymore, and has been replaced by @npmcli/package-json",
-      "dev": true
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "12.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mojaloop/central-services-error-handling": "13.0.6",
+        "@mojaloop/central-services-error-handling": "13.0.7",
         "@mojaloop/central-services-health": "15.0.4",
         "@mojaloop/central-services-logger": "11.5.5",
         "@mojaloop/central-services-metrics": "12.4.5",
-        "@mojaloop/central-services-shared": "18.18.2",
+        "@mojaloop/central-services-shared": "18.21.0",
         "@mojaloop/central-services-stream": "11.5.1",
         "@mojaloop/event-sdk": "14.1.5",
         "@mojaloop/ml-number": "11.2.7",
@@ -21,7 +21,7 @@
         "json-rules-engine": "7.3.1",
         "leaked-handles": "5.2.0",
         "moment": "2.30.1",
-        "mongoose": "8.10.1",
+        "mongoose": "8.12.0",
         "mustache": "4.2.0",
         "request-promise": "4.2.6",
         "rxjs": "7.8.2",
@@ -40,7 +40,7 @@
         "sinon": "19.0.2",
         "standard": "17.1.2",
         "standard-version": "^9.5.0",
-        "tap-spec": "^5.0.0",
+        "tap-mocha-reporter": "^5.0.4",
         "tap-xunit": "2.4.1",
         "tape": "5.9.0",
         "tapes": "4.1.0"
@@ -1002,9 +1002,10 @@
       }
     },
     "node_modules/@mojaloop/central-services-error-handling": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.0.6.tgz",
-      "integrity": "sha512-tDOhUSr9MSVpqtBkn3oNc8TGJ/TGav8W/UmqW71WskF8musL5toEv0nZOAEn9nxKPb/Xj0b83EYeAOBiOD6ozA==",
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.0.7.tgz",
+      "integrity": "sha512-ofcNho03tAw5ZN9+nS9j4LiS0Q41zcipv4OyB7BjQVsFx2Z4QY1Rf3XMqLmNwU5EyeGdVDwypYmFGYrn5GojBg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "lodash": "4.17.21"
@@ -1051,17 +1052,18 @@
       }
     },
     "node_modules/@mojaloop/central-services-shared": {
-      "version": "18.18.2",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.18.2.tgz",
-      "integrity": "sha512-hBXcuxwhdu4IBDd3wG5FYLJUOZE2bR31KPbPAd3j1gHCDBZMAPf0PEPh6GKNHor4v1pzlrPl5PcvctXDit6j5A==",
+      "version": "18.21.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.21.0.tgz",
+      "integrity": "sha512-k7vFBlIeYpli+8GQdGBMt7ykg4a18axo/As2G3wEemloA8kQZvK76rNWQy9i1URxc0hDT8W5xSHhXHIwwF2UPg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.1.1",
         "@hapi/catbox-memory": "5.0.1",
         "@hapi/hapi": "21.3.12",
         "@hapi/joi-date": "2.0.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.3",
-        "@mojaloop/sdk-standard-components": "19.6.6",
-        "axios": "1.7.9",
+        "@mojaloop/sdk-standard-components": "19.7.1",
+        "axios": "1.8.1",
         "clone": "2.1.2",
         "dotenv": "16.4.7",
         "env-var": "7.5.0",
@@ -1215,6 +1217,7 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.5.4.tgz",
       "integrity": "sha512-ENHrRiR52ZgG7VbKIHBcWnKE9R1NQntgUSD6xG6o961+PM3Cq/qTXirGhjiAjO8Q9IaxlU9LoyOBZHTZs5raYQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mojaloop/central-services-error-handling": "13.0.6",
         "@mojaloop/central-services-logger": "11.5.5",
@@ -1229,42 +1232,106 @@
         "@rollup/rollup-linux-x64-musl": "4.34.8"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/bignumber.js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/ilp-packet": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
-      "integrity": "sha512-QEGqY0HzGrue4r+4GWWe7lB7Xvjij4cyc2XeOTHYmwkO0BjgwzJW85mZJzR9q5HmK8zdFkN6C0CfedAaYiUv9w==",
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "bignumber.js": "^5.0.0",
-        "extensible-error": "^1.0.2",
-        "long": "^3.2.0",
-        "oer-utils": "^1.3.2"
+        "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
-      "engines": {
-        "node": ">=0.6"
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/catbox-memory": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
-    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/oer-utils": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA=="
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
-    "node_modules/@mojaloop/sdk-standard-components": {
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-error-handling": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.0.6.tgz",
+      "integrity": "sha512-tDOhUSr9MSVpqtBkn3oNc8TGJ/TGav8W/UmqW71WskF8musL5toEv0nZOAEn9nxKPb/Xj0b83EYeAOBiOD6ozA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-safe-stringify": "2.1.1",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/central-services-shared": {
+      "version": "18.18.2",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.18.2.tgz",
+      "integrity": "sha512-hBXcuxwhdu4IBDd3wG5FYLJUOZE2bR31KPbPAd3j1gHCDBZMAPf0PEPh6GKNHor4v1pzlrPl5PcvctXDit6j5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hapi/catbox": "12.1.1",
+        "@hapi/catbox-memory": "5.0.1",
+        "@hapi/hapi": "21.3.12",
+        "@hapi/joi-date": "2.0.1",
+        "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.3",
+        "@mojaloop/sdk-standard-components": "19.6.6",
+        "axios": "1.7.9",
+        "clone": "2.1.2",
+        "dotenv": "16.4.7",
+        "env-var": "7.5.0",
+        "event-stream": "4.0.1",
+        "fast-safe-stringify": "2.1.1",
+        "immutable": "5.0.3",
+        "ioredis": "5.5.0",
+        "joi": "17.13.3",
+        "lodash": "4.17.21",
+        "mustache": "4.2.0",
+        "openapi-backend": "5.11.1",
+        "raw-body": "3.0.0",
+        "rc": "1.2.8",
+        "shins": "2.6.0",
+        "ulidx": "2.4.1",
+        "uuid4": "2.0.3",
+        "widdershins": "4.0.1",
+        "yaml": "2.7.0"
+      },
+      "peerDependencies": {
+        "@mojaloop/central-services-error-handling": ">=13.x.x",
+        "@mojaloop/central-services-metrics": ">=12.x.x",
+        "@mojaloop/event-sdk": ">=14.1.1",
+        "ajv": "8.x.x",
+        "ajv-keywords": "5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@mojaloop/central-services-error-handling": {
+          "optional": false
+        },
+        "@mojaloop/central-services-logger": {
+          "optional": false
+        },
+        "@mojaloop/central-services-metrics": {
+          "optional": false
+        },
+        "@mojaloop/event-sdk": {
+          "optional": false
+        },
+        "ajv": {
+          "optional": false
+        },
+        "ajv-keyboards": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/sdk-standard-components": {
       "version": "19.6.6",
       "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.6.6.tgz",
       "integrity": "sha512-6zRplfMu1DZfgxdoyu58RK8O4UVAV7Ghb62UNGlUkvGT5woo/ebt9ZJKSbR6YjzkFhPXfrVo1+NaYRfGSRdRig==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mojaloop/ml-schema-transformer-lib": "^2.5.3",
         "axios": "1.7.9",
@@ -1277,10 +1344,85 @@
         "jws": "4.0.0"
       }
     },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/@mojaloop/sdk-standard-components/node_modules/ilp-packet": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.3.tgz",
+      "integrity": "sha512-FBsiPQbHPdLPI6jdA+sQO+4fFBuMc212yCdNXMqoGJdic2GFHF/E8P9bTorIVRZRVExhWDE5givqCMguupW8VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extensible-error": "^1.0.2",
+        "oer-utils": "^5.1.2"
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/ilp-packet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+      "integrity": "sha512-QEGqY0HzGrue4r+4GWWe7lB7Xvjij4cyc2XeOTHYmwkO0BjgwzJW85mZJzR9q5HmK8zdFkN6C0CfedAaYiUv9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bignumber.js": "^5.0.0",
+        "extensible-error": "^1.0.2",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
+      }
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/ilp-packet/node_modules/oer-utils": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
+      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/@mojaloop/sdk-standard-components": {
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.7.1.tgz",
+      "integrity": "sha512-VnfhZANqpa+4iVybwPeafB7bfcQkiochO95X3oQ1YFuxblmFf9WyxMLtevG6PGv2OK9j/tI17QQqbuoL60/Gag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mojaloop/ml-schema-transformer-lib": "2.5.4",
+        "axios": "1.8.1",
+        "axios-retry": "4.5.0",
+        "base64url": "3.0.1",
+        "fast-safe-stringify": "2.1.1",
+        "ilp-packet": "3.1.3",
+        "ilp-packet-v1": "2.2.0",
+        "jsonwebtoken": "9.0.2",
+        "jws": "4.0.0"
+      }
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.0.tgz",
       "integrity": "sha512-+ywrb0AqkfaYuhHs6LxKWgqbh3I72EpEgESCw37o+9qPx9WTCkgDm2B+eMrwehGtHBWHFU4GXvnSCNiFhhausg==",
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1389,6 +1531,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1481,7 +1624,8 @@
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "license": "MIT"
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -1511,12 +1655,14 @@
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -2008,9 +2154,10 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2021,6 +2168,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -2057,6 +2205,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2262,6 +2411,7 @@
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
       "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -2318,7 +2468,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
@@ -2330,12 +2481,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha512-Zy8ZXMyxIT6RMTeY7OP/bDndfj6bwCan7SS98CEndS6deHwWPpseeHlwarNcBim+etXnF9HBc1non5JgDaJU1g==",
       "dev": true
     },
     "node_modules/builtins": {
@@ -2676,6 +2821,16 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
       }
     },
     "node_modules/colorspace": {
@@ -3783,6 +3938,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4981,7 +5137,8 @@
     "node_modules/extensible-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
-      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g==",
+      "license": "ISC"
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
@@ -5307,6 +5464,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5376,6 +5534,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6425,6 +6584,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.3.tgz",
       "integrity": "sha512-FBsiPQbHPdLPI6jdA+sQO+4fFBuMc212yCdNXMqoGJdic2GFHF/E8P9bTorIVRZRVExhWDE5givqCMguupW8VA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "extensible-error": "^1.0.2",
         "oer-utils": "^5.1.2"
@@ -6434,6 +6594,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ilp-packet-v1/-/ilp-packet-v1-2.2.0.tgz",
       "integrity": "sha512-bNsvjJ2/5Pl/qoVoSo4e/ZPoKv3xSm0VCO3fOPS+Yl5L4SZ6QRI972vclZKBwWDT19he2TgFZAmwe4RUzQ31jg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bignumber.js": "^5.0.0",
         "extensible-error": "^1.0.2",
@@ -6445,6 +6606,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
       "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -6453,6 +6615,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.6"
       }
@@ -6460,7 +6623,8 @@
     "node_modules/ilp-packet-v1/node_modules/oer-utils": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA=="
+      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA==",
+      "license": "Apache-2.0"
     },
     "node_modules/immutable": {
       "version": "5.0.3",
@@ -6773,18 +6937,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6938,6 +7090,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7603,6 +7756,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -7624,6 +7778,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7634,6 +7789,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -7678,6 +7834,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7688,6 +7845,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -7877,7 +8035,8 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
@@ -7887,12 +8046,14 @@
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -7903,17 +8064,20 @@
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7923,7 +8087,8 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -8011,6 +8176,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-any-cjs/-/map-any-cjs-1.0.1.tgz",
       "integrity": "sha512-sTO3ceFtm5rT9+sUtrBHiQgd24SlMrIBGZkoLBFSQRbT1GzORdiO0SDaQqDlUSvBsGxEywHCA7CyX4tWPolSEw==",
+      "license": "ISC",
       "engines": {
         "node": ">= 18"
       }
@@ -8036,6 +8202,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/map-transform-cjs/-/map-transform-cjs-0.2.0.tgz",
       "integrity": "sha512-Dn2biqrp6w0OZq6sXh3shMBgpPcN13UL9kpwoLELCoWMXWcwkzjFLPagoL6sq1bZZpEREvW3YEooZtpPlYDWpw==",
+      "license": "ISC",
       "dependencies": {
         "deepmerge": "^4.3.1",
         "map-any-cjs": "^1.0.1"
@@ -8136,7 +8303,8 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -8374,6 +8542,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -8475,9 +8663,10 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.13.1.tgz",
-      "integrity": "sha512-gdq40tX8StmhP6akMp1pPoEVv+9jTYFSrga/g23JxajPAQhH39ysZrHGzQCSd9PEOnuEQEdjIWqxO7ZSwC0w7Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.1.tgz",
+      "integrity": "sha512-GnHWIm4GtgREkssWRv9vYKNvqwbLd8WL5hCW3nCqzI2OxEZ6Q5g6vc3J6L1Grz0x1hx1wmYAprLlRr3kzBLcJg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
         "bson": "^6.10.3",
@@ -8487,7 +8676,7 @@
         "node": ">=16.20.1"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.632.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
         "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
@@ -8523,6 +8712,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
@@ -8839,13 +9029,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.10.1.tgz",
-      "integrity": "sha512-5beTeBZnJNndRXU9rxPol0JmTWZMAtgkPbooROkGilswvrZALDERY4cJrGZmgGwDS9dl0mxiB7si+Mv9Yms2fg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.12.0.tgz",
+      "integrity": "sha512-FXZIngJBTt/gvb6uHZHiROy3Mk3EOjNpD0m+GBRfG+twuEntnMjfxwcA94YbYIulf9LkBozt7H8w2OJpqHdUxA==",
+      "license": "MIT",
       "dependencies": {
         "bson": "^6.10.1",
         "kareem": "2.6.3",
-        "mongodb": "~6.13.0",
+        "mongodb": "~6.14.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -9569,7 +9760,8 @@
     "node_modules/oer-utils/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -9831,15 +10023,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha512-LpH1Cf5EYuVjkBvCDBYvkUPh+iv2bk3FHflxHkpCYT0/FZ1d3N3uJaLiHr4yGuMcFUhv6eAivitTvWZI4B/chg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -10084,15 +10267,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/plur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-      "integrity": "sha512-qSnKBSZeDY8ApxwhfVIwKwF36KVJqb1/9nzYYq3j3vdwocULCXT8f8fQGkiw1Nk9BGfxiDagEe/pwakA+bOBqw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -10185,20 +10359,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
-      "integrity": "sha512-H2enpsxzDhuzRl3zeSQpQMirn8dB0Z/gxW96j06tMfTviUWvX14gjKb7qd1gtkUyYhDPuoNe00K5PqNvy2oQNg==",
-      "dev": true,
-      "dependencies": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/process": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
@@ -10286,7 +10446,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
@@ -10432,12 +10593,6 @@
       "bin": {
         "rc": "cli.js"
       }
-    },
-    "node_modules/re-emitter": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
-      "integrity": "sha512-bHJul9CWcocrS+w5e5QrKYXV9NkbSA9hxSEyhYuctwm6keY9NXR2Xt/4A0vbMP0QvuwyfEyb4bkowYXv1ziEbg==",
-      "dev": true
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -11651,6 +11806,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -12334,67 +12490,65 @@
         "node": ">= 6"
       }
     },
-    "node_modules/tap-out": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-2.1.0.tgz",
-      "integrity": "sha512-LJE+TBoVbOWhwdz4+FQk40nmbIuxJLqaGvj3WauQw3NYYU5TdjoV3C0x/yq37YAvVyi+oeBXmWnxWSjJ7IEyUw==",
+    "node_modules/tap-mocha-reporter": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.4.tgz",
+      "integrity": "sha512-J+YMO8B7lq1O6Zxd/jeuG27vJ+Y4tLiRMKPSb7KR6FVh86k3Rq1TwYc2GKPyIjCbzzdMdReh3Vfz9L5cg1Z2Bw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "re-emitter": "1.1.3",
-        "readable-stream": "2.2.9",
-        "split": "1.0.0",
-        "trim": "0.0.1"
+        "color-support": "^1.1.0",
+        "debug": "^4.1.1",
+        "diff": "^4.0.1",
+        "escape-string-regexp": "^2.0.0",
+        "glob": "^7.0.5",
+        "tap-parser": "^11.0.0",
+        "tap-yaml": "^1.0.0",
+        "unicode-length": "^2.0.2"
       },
       "bin": {
-        "tap-out": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-out/node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
-      "dev": true
-    },
-    "node_modules/tap-out/node_modules/readable-stream": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha512-iuxqX7b7FYt08AriYECxUsK9KTXE3A/FenxIa3IPmvANHxaTP/wGIwwf+IidvvIDk/MsCp/oEV6A8CXo4SDcCg==",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "~1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~1.0.0",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/tap-out/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/tap-out/node_modules/split": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "integrity": "sha512-3SVfJe2A0WZg3D+ZEtXqYkvpSGAVaZ1MgufNCeHioBESCqQFsuT1VcQufiopBfJZqh92ZwQ6ddL378iUSbqVNQ==",
-      "dev": true,
-      "dependencies": {
-        "through": "2"
+        "tap-mocha-reporter": "index.js"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 8"
       }
     },
-    "node_modules/tap-out/node_modules/string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+    "node_modules/tap-mocha-reporter/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tap-mocha-reporter/node_modules/tap-parser": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-11.0.2.tgz",
+      "integrity": "sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "events-to-array": "^1.0.1",
+        "minipass": "^3.1.6",
+        "tap-yaml": "^1.0.0"
+      },
+      "bin": {
+        "tap-parser": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/tap-parser": {
@@ -12412,113 +12566,6 @@
       },
       "optionalDependencies": {
         "readable-stream": "^2"
-      }
-    },
-    "node_modules/tap-spec": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
-      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^1.0.0",
-        "duplexer": "^0.1.1",
-        "figures": "^1.4.0",
-        "lodash": "^4.17.10",
-        "pretty-ms": "^2.1.0",
-        "repeat-string": "^1.5.2",
-        "tap-out": "^2.1.0",
-        "through2": "^2.0.0"
-      },
-      "bin": {
-        "tap-spec": "bin/cmd.js",
-        "tspec": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-spec/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-spec/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
       }
     },
     "node_modules/tap-xunit": {
@@ -12547,6 +12594,26 @@
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/tap-yaml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.2.tgz",
+      "integrity": "sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yaml": "^1.10.2"
+      }
+    },
+    "node_modules/tap-yaml/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tape": {
@@ -12785,6 +12852,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
       "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -12799,13 +12867,6 @@
       "dependencies": {
         "random-poly-fill": "^1.0.1"
       }
-    },
-    "node_modules/trim": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
-      "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
-      "deprecated": "Use String.prototype.trim() instead",
-      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
@@ -13149,6 +13210,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
+    "node_modules/unicode-length": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.1.0.tgz",
+      "integrity": "sha512-4bV582zTV9Q02RXBxSUMiuN/KHo5w4aTojuKTNT96DIKps/SIawFp7cS5Mu25VuY1AioGXrmYyzKZUzh8OqoUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -13299,6 +13370,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -13326,6 +13398,7 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
       "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2993,8 +2993,7 @@
       "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dev": true,
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -3005,9 +3004,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
       "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3017,9 +3013,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
       "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3037,8 +3030,7 @@
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
+        "lodash": "^4.17.15"
       },
       "engines": {
         "node": ">=10"
@@ -3060,7 +3052,6 @@
         "git-semver-tags": "^4.1.1",
         "lodash": "^4.17.15",
         "normalize-package-data": "^3.0.0",
-        "q": "^1.5.1",
         "read-pkg": "^3.0.0",
         "read-pkg-up": "^3.0.0",
         "through2": "^4.0.0"
@@ -3074,9 +3065,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
       "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3086,9 +3074,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
       "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3098,9 +3083,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
       "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3110,9 +3092,6 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
       "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
       "dev": true,
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -3123,8 +3102,7 @@
       "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
       "dev": true,
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -3216,8 +3194,7 @@
         "conventional-commits-parser": "^3.2.0",
         "git-raw-commits": "^2.0.8",
         "git-semver-tags": "^4.1.1",
-        "meow": "^8.0.0",
-        "q": "^1.5.1"
+        "meow": "^8.0.0"
       },
       "bin": {
         "conventional-recommended-bump": "cli.js"
@@ -10492,17 +10469,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "tapes": "4.1.0"
   },
   "overrides": {
+    "httpsnippet":"3.0.1",
     "async": "3.2.6",
     "postcss": {
       "nanoid": "^3.3.8"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   ],
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "npx tape 'test/unit/**/*.test.js' | tap-spec",
+    "test:unit": "npx tape 'test/unit/**/*.test.js' | tap-mocha-reporter spec",
     "test:xunit": "npx tape 'test/unit/**/**.test.js' | tap-xunit > ./test/results/xunit.xml",
-    "test:coverage": "npx nyc tapes -- 'test/unit/**/*.test.js' | tap-spec; nyc report ---reporter=text",
+    "test:coverage": "npx nyc tapes -- 'test/unit/**/*.test.js' | tap-mocha-reporter spec; nyc report ---reporter=text",
     "test:coverage-check": "npm run test:coverage && nyc check-coverage",
     "start": "node ./src/index.js",
     "standard": "npx standard",
@@ -49,11 +49,11 @@
     "snapshot": "npx standard-version --no-verify --skip.changelog --prerelease snapshot --releaseCommitMessageFormat 'chore(snapshot): {{currentTag}}'"
   },
   "dependencies": {
-    "@mojaloop/central-services-error-handling": "13.0.6",
+    "@mojaloop/central-services-error-handling": "13.0.7",
     "@mojaloop/central-services-health": "15.0.4",
     "@mojaloop/central-services-logger": "11.5.5",
     "@mojaloop/central-services-metrics": "12.4.5",
-    "@mojaloop/central-services-shared": "18.18.2",
+    "@mojaloop/central-services-shared": "18.21.0",
     "@mojaloop/central-services-stream": "11.5.1",
     "@mojaloop/event-sdk": "14.1.5",
     "@mojaloop/ml-number": "11.2.7",
@@ -61,7 +61,7 @@
     "json-rules-engine": "7.3.1",
     "leaked-handles": "5.2.0",
     "moment": "2.30.1",
-    "mongoose": "8.10.1",
+    "mongoose": "8.12.0",
     "mustache": "4.2.0",
     "request-promise": "4.2.6",
     "rxjs": "7.8.2",
@@ -80,7 +80,7 @@
     "sinon": "19.0.2",
     "standard": "17.1.2",
     "standard-version": "^9.5.0",
-    "tap-spec": "^5.0.0",
+    "tap-mocha-reporter": "^5.0.4",
     "tap-xunit": "2.4.1",
     "tape": "5.9.0",
     "tapes": "4.1.0"


### PR DESCRIPTION
This PR solve issue number: [#4037](https://github.com/mojaloop/project/issues/4037) from mojaloop/project

In this please, consider the commit after 4th of March. As I have picked up wrong approach, in which I have used patch-package to resolve the deprecation issue. So, I backtracked first and tried to solve the issue from the roots.

Packages I have solved
0. tap-spec -> replaced it with tap-mocha-reporter. Because of deprecated trim package
1. q -> Just removed it
2. mkdirp-promise -> replace it with mkdirp
3. stringify-package -> @npmcli/package-json
4. har-validator -> partially -> httpsnippet's version 1.25.0 was using har-validator -> but it's latest version was not using har-validator -> So overriden it.
4.1 But, mockgoose -> mongodb-prebuilt -> mongodb-download -> request -> har-validator -> Not resolved

Before:
![image](https://github.com/user-attachments/assets/d6a7fbc5-566e-4450-b82f-0141b32d8899)

After:
![image](https://github.com/user-attachments/assets/451c21f8-5299-408e-8620-edc5d3dd8fe7)

